### PR TITLE
Introduce a version bound for typed-process

### DIFF
--- a/repld.cabal
+++ b/repld.cabal
@@ -15,7 +15,7 @@ executable repld
     optparse-applicative,
     safe-exceptions,
     stm,
-    typed-process,
+    typed-process >= 0.2.5,
   default-language: Haskell2010
   ghc-options: -Wall -O -threaded -with-rtsopts=-N
   main-is: Main.hs


### PR DESCRIPTION
Because of usage of `withProcessWait`.